### PR TITLE
Fix invalid UTF-8 encoding with Python 3

### DIFF
--- a/adanet/core/report_accessor.py
+++ b/adanet/core/report_accessor.py
@@ -111,7 +111,8 @@ def _create_subnetwork_report_proto(materialized_subnetwork_report):
         field[key].bool_value = value
       elif isinstance(value, (six.string_types, six.binary_type)):
         # Proto requires unicode strings.
-        field[key].string_value = six.u(value)
+        unicode_string = six.u(value) if six.PY2 else value.decode("unicode_escape")
+        field[key].string_value = unicode_string
       elif isinstance(value, int):
         field[key].int_value = value
       elif isinstance(value, float):


### PR DESCRIPTION
This fix fixes #4

- UTF-8 codec can't decode byte 0x83.
- In Python 2, the six.u(value) is decoded with the unicode-escape codec.
- Non-UTF-8 strings must be converted to unicode objects before being added.