### PR TITLE
Pin TravisCI Bazel installation to v0.20.0

### DIFF
--- a/oss_scripts/oss_pip_install.sh
+++ b/oss_scripts/oss_pip_install.sh
@@ -33,10 +33,10 @@ fi
 pip install -q -U numpy
 
 # Install Bazel for tests.
-# Step 1: Install the JDK
-sudo apt-get install openjdk-8-jdk
+# Step 1: Install required packages
+sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python
 
-# Step 2: Install Bazel using binary installer
+# Step 2: Download Bazel binary installer
 wget https://github.com/bazelbuild/bazel/releases/download/"$BAZEL_VERSION"/bazel-"$BAZEL_VERSION"-installer-linux-x86_64.sh
 
 # Step 3: Install Bazel

--- a/oss_scripts/oss_pip_install.sh
+++ b/oss_scripts/oss_pip_install.sh
@@ -17,6 +17,8 @@
 set -v  # print commands as they're executed
 set -e  # fail and exit on any command erroring
 
+BAZEL_VERSION=0.20.0
+
 : "${TF_VERSION:?}"
 
 if [[ "$TF_VERSION" == "tf-nightly"  ]]
@@ -34,12 +36,12 @@ pip install -q -U numpy
 # Step 1: Install the JDK
 sudo apt-get install openjdk-8-jdk
 
-# Step 2: Add Bazel distribution URI as a package source
-echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+# Step 2: Install Bazel using binary installer
+wget https://github.com/bazelbuild/bazel/releases/download/"$BAZEL_VERSION"/bazel-"$BAZEL_VERSION"-installer-linux-x86_64.sh
 
-# Step 3: Install and update Bazel
-sudo apt-get update && sudo apt-get install bazel
+# Step 3: Install Bazel
+chmod +x bazel-"$BAZEL_VERSION"-installer-linux-x86_64.sh
+./bazel-"$BAZEL_VERSION"-installer-linux-x86_64.sh
 
 # Build adanet pip packaging script
 bazel build //adanet/pip_package:build_pip_package

--- a/oss_scripts/oss_pip_install.sh
+++ b/oss_scripts/oss_pip_install.sh
@@ -42,6 +42,7 @@ wget https://github.com/bazelbuild/bazel/releases/download/"$BAZEL_VERSION"/baze
 # Step 3: Install Bazel
 chmod +x bazel-"$BAZEL_VERSION"-installer-linux-x86_64.sh
 ./bazel-"$BAZEL_VERSION"-installer-linux-x86_64.sh --user
+export PATH="$PATH:$HOME/bin"
 
 # Build adanet pip packaging script
 bazel build //adanet/pip_package:build_pip_package

--- a/oss_scripts/oss_pip_install.sh
+++ b/oss_scripts/oss_pip_install.sh
@@ -41,7 +41,7 @@ wget https://github.com/bazelbuild/bazel/releases/download/"$BAZEL_VERSION"/baze
 
 # Step 3: Install Bazel
 chmod +x bazel-"$BAZEL_VERSION"-installer-linux-x86_64.sh
-./bazel-"$BAZEL_VERSION"-installer-linux-x86_64.sh
+./bazel-"$BAZEL_VERSION"-installer-linux-x86_64.sh --user
 
 # Build adanet pip packaging script
 bazel build //adanet/pip_package:build_pip_package


### PR DESCRIPTION
To fix broken build: https://travis-ci.org/tensorflow/adanet/builds/470180930

And to prevent future builds from breaking when Bazel releases a new package.