### PR TITLE
Adding .decode() to convert bytes to string

### DIFF
--- a/adanet/core/estimator.py
+++ b/adanet/core/estimator.py
@@ -1143,7 +1143,7 @@ class Estimator(tf.estimator.Estimator):
       raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), filename)
 
     with tf.io.gfile.GFile(filename, "rb") as gfile:
-      return _Architecture.deserialize(gfile.read())
+      return _Architecture.deserialize(gfile.read().decode())
 
   def _find_ensemble_candidate(self, ensemble_candidate_name,
                                ensemble_candidates):


### PR DESCRIPTION
gfile.read() outputs bytes instead of string. This causes an error when _Architecture.deserialize() uses json.loads() which requires a string object. Source is https://docs.python.org/3.6/library/stdtypes.html#bytes