### PR TITLE
To comply with PEP 396 - expose __version__

### DIFF
--- a/adanet/__init__.py
+++ b/adanet/__init__.py
@@ -36,6 +36,8 @@ from adanet.ensemble import MixtureWeightType
 from adanet.ensemble import WeightedSubnetwork
 from adanet.subnetwork import Subnetwork
 
+from adanet.version import __version__
+
 __all__ = [
     "AutoEnsembleEstimator",
     "AutoEnsembleSubestimator",


### PR DESCRIPTION
While testing a newly released `0.8.0` I figured out, that adanet does not expose the version as many python packages do or as [PEP-396](https://www.python.org/dev/peps/pep-0396/) recommends

Other examples:
- TFhub - https://github.com/tensorflow/hub/blob/master/tensorflow_hub/__init__.py#L48
- tfx - https://github.com/tensorflow/tfx/blob/master/tfx/__init__.py#L18
- addons - https://github.com/tensorflow/addons/blob/master/tensorflow_addons/__init__.py#L32
- tensorboard - https://github.com/tensorflow/tensorboard/blob/master/tensorboard/__init__.py#L99