### PR TITLE
make gpu allow_growth=True

### DIFF
--- a/adanet/core/ensemble_builder.py
+++ b/adanet/core/ensemble_builder.py
@@ -679,6 +679,7 @@ class _SubnetworkManager(object):
             model_dir=os.path.join(config.model_dir, "assets", name))
       else:
         subnetwork_config = tf.estimator.RunConfig()
+      if subnetwork_config.session_config is None:
         subnetwork_config.session_config = tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))
 
       build_subnetwork = functools.partial(

--- a/adanet/core/ensemble_builder.py
+++ b/adanet/core/ensemble_builder.py
@@ -679,6 +679,7 @@ class _SubnetworkManager(object):
             model_dir=os.path.join(config.model_dir, "assets", name))
       else:
         subnetwork_config = tf.estimator.RunConfig()
+        subnetwork_config.session_config = tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))
 
       build_subnetwork = functools.partial(
           subnetwork_builder.build_subnetwork,

--- a/adanet/core/ensemble_builder_test.py
+++ b/adanet/core/ensemble_builder_test.py
@@ -432,8 +432,7 @@ class EnsembleBuilderTest(tu.AdanetTestCase):
       else:
         labels = tf.constant([0, 1])
 
-      subnetwork_config = tf.estimator.RunConfig()
-      subnetwork_config.session_config = tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))
+      session_config = tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))
 
       subnetwork_spec = subnetwork_manager.build_subnetwork_spec(
           name="test",
@@ -442,8 +441,7 @@ class EnsembleBuilderTest(tu.AdanetTestCase):
           features=features,
           mode=mode,
           labels=labels,
-          previous_ensemble=previous_ensemble, 
-          config=subnetwork_config)
+          previous_ensemble=previous_ensemble)
       ensembler_kwargs = {}
       if ensembler_class is ComplexityRegularizedEnsembler:
         ensembler_kwargs.update({
@@ -477,7 +475,7 @@ class EnsembleBuilderTest(tu.AdanetTestCase):
         self.assertAllEqual(want_replay_indices,
                             ensemble_spec.architecture.replay_indices)
 
-      with tf_compat.v1.Session(graph=g, config=subnetwork_config.session_config).as_default() as sess:
+      with tf_compat.v1.Session(graph=g, config=session_config).as_default() as sess:
         sess.run(tf_compat.v1.global_variables_initializer())
 
         # Equals the number of subnetwork and ensemble trainable variables,

--- a/adanet/core/ensemble_builder_test.py
+++ b/adanet/core/ensemble_builder_test.py
@@ -46,6 +46,10 @@ from tensorflow.python.training import training_util
 from tensorflow_estimator.python.estimator.head import binary_class_head
 from tensorflow_estimator.python.estimator.head import multi_head as multi_head_lib
 
+GPU_OPTIONS = tf.GPUOptions(allow_growth=True)
+CONFIG = tf.ConfigProto(gpu_options=GPU_OPTIONS)
+
+
 
 class _Builder(Builder):
 
@@ -471,7 +475,7 @@ class EnsembleBuilderTest(tu.AdanetTestCase):
         self.assertAllEqual(want_replay_indices,
                             ensemble_spec.architecture.replay_indices)
 
-      with tf_compat.v1.Session(graph=g).as_default() as sess:
+      with tf_compat.v1.Session(graph=g, config=CONFIG).as_default() as sess:
         sess.run(tf_compat.v1.global_variables_initializer())
 
         # Equals the number of subnetwork and ensemble trainable variables,

--- a/adanet/core/ensemble_builder_test.py
+++ b/adanet/core/ensemble_builder_test.py
@@ -46,8 +46,6 @@ from tensorflow.python.training import training_util
 from tensorflow_estimator.python.estimator.head import binary_class_head
 from tensorflow_estimator.python.estimator.head import multi_head as multi_head_lib
 
-GPU_OPTIONS = tf.GPUOptions(allow_growth=True)
-CONFIG = tf.ConfigProto(gpu_options=GPU_OPTIONS)
 
 
 
@@ -434,6 +432,9 @@ class EnsembleBuilderTest(tu.AdanetTestCase):
       else:
         labels = tf.constant([0, 1])
 
+      subnetwork_config = tf.estimator.RunConfig()
+      subnetwork_config.session_config = tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))
+
       subnetwork_spec = subnetwork_manager.build_subnetwork_spec(
           name="test",
           subnetwork_builder=subnetwork_builder,
@@ -441,7 +442,8 @@ class EnsembleBuilderTest(tu.AdanetTestCase):
           features=features,
           mode=mode,
           labels=labels,
-          previous_ensemble=previous_ensemble)
+          previous_ensemble=previous_ensemble, 
+          config=subnetwork_config)
       ensembler_kwargs = {}
       if ensembler_class is ComplexityRegularizedEnsembler:
         ensembler_kwargs.update({
@@ -475,7 +477,7 @@ class EnsembleBuilderTest(tu.AdanetTestCase):
         self.assertAllEqual(want_replay_indices,
                             ensemble_spec.architecture.replay_indices)
 
-      with tf_compat.v1.Session(graph=g, config=CONFIG).as_default() as sess:
+      with tf_compat.v1.Session(graph=g, config=subnetwork_config.session_config).as_default() as sess:
         sess.run(tf_compat.v1.global_variables_initializer())
 
         # Equals the number of subnetwork and ensemble trainable variables,

--- a/adanet/core/estimator.py
+++ b/adanet/core/estimator.py
@@ -53,6 +53,10 @@ from tensorflow.python.util import deprecation
 from tensorflow_estimator.python.estimator import util
 # pylint: enable=g-direct-tensorflow-import
 
+GPU_OPTIONS = tf.GPUOptions(allow_growth=True)
+CONFIG = tf.ConfigProto(gpu_options=GPU_OPTIONS)
+
+
 
 class _StopAfterTrainingHook(tf_compat.SessionRunHook):
   """Hook that requests stop once iteration is over."""
@@ -1390,7 +1394,7 @@ class Estimator(tf.estimator.Estimator):
                  current_iteration.number)
     for hook in input_hooks:
       hook.begin()
-    with tf_compat.v1.Session() as sess:
+    with tf_compat.v1.Session(config=CONFIG) as sess:
       init = tf.group(
           tf_compat.v1.global_variables_initializer(),
           tf_compat.v1.local_variables_initializer(),
@@ -1470,7 +1474,7 @@ class Estimator(tf.estimator.Estimator):
     ]
     for hook in input_hooks:
       hook.begin()
-    with tf_compat.v1.Session() as sess:
+    with tf_compat.v1.Session(config=CONFIG) as sess:
       init = tf.group(
           tf_compat.v1.global_variables_initializer(),
           tf_compat.v1.local_variables_initializer(),

--- a/adanet/core/summary_test.py
+++ b/adanet/core/summary_test.py
@@ -35,6 +35,11 @@ import tensorflow as tf
 from tensorflow.python.ops import summary_ops_v2
 # pylint: enable=g-direct-tensorflow-import
 
+GPU_OPTIONS = tf.GPUOptions(allow_growth=True)
+CONFIG = tf.ConfigProto(gpu_options=GPU_OPTIONS)
+
+
+
 
 def decode(proto_str):
   """Decodes a proto string."""
@@ -361,7 +366,7 @@ class ScopedSummaryTest(parameterized.TestCase, tf.test.TestCase):
     if nest_graph:
       with tf.Graph().as_default():
         scoped_summary2.scalar("c2", tf.constant(2))
-        with tf.Session() as sess:
+        with tf.Session(config=CONFIG) as sess:
           summaries = scoped_summary2.merge_all()
           tf.logging.warn("summaries %s", summaries)
           summary = tf.Summary()
@@ -369,7 +374,7 @@ class ScopedSummaryTest(parameterized.TestCase, tf.test.TestCase):
           self.assertEqual(["c2"], [s.tag for s in summary.value])
           self.assertEqual([2], [s.simple_value for s in summary.value])
 
-    with tf.Session() as sess:
+    with tf.Session(config=CONFIG) as sess:
       for scoped_summary in [scoped_summary0, scoped_summary1, scoped_summary2]:
         summaries = scoped_summary.merge_all()
         summary = tf.Summary()

--- a/adanet/core/summary_test.py
+++ b/adanet/core/summary_test.py
@@ -35,9 +35,6 @@ import tensorflow as tf
 from tensorflow.python.ops import summary_ops_v2
 # pylint: enable=g-direct-tensorflow-import
 
-GPU_OPTIONS = tf.GPUOptions(allow_growth=True)
-CONFIG = tf.ConfigProto(gpu_options=GPU_OPTIONS)
-
 
 
 
@@ -363,10 +360,12 @@ class ScopedSummaryTest(parameterized.TestCase, tf.test.TestCase):
     scoped_summary2.scalar("c0", c0)
     scoped_summary2.scalar("c1", c1)
 
+    config = tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))
+
     if nest_graph:
       with tf.Graph().as_default():
         scoped_summary2.scalar("c2", tf.constant(2))
-        with tf.Session(config=CONFIG) as sess:
+        with tf.Session(config=config) as sess:
           summaries = scoped_summary2.merge_all()
           tf.logging.warn("summaries %s", summaries)
           summary = tf.Summary()
@@ -374,7 +373,7 @@ class ScopedSummaryTest(parameterized.TestCase, tf.test.TestCase):
           self.assertEqual(["c2"], [s.tag for s in summary.value])
           self.assertEqual([2], [s.simple_value for s in summary.value])
 
-    with tf.Session(config=CONFIG) as sess:
+    with tf.Session(config=config) as sess:
       for scoped_summary in [scoped_summary0, scoped_summary1, scoped_summary2]:
         summaries = scoped_summary.merge_all()
         summary = tf.Summary()

--- a/adanet/ensemble/weighted_test.py
+++ b/adanet/ensemble/weighted_test.py
@@ -34,6 +34,10 @@ from tensorflow.python.eager import context
 from tensorflow.python.framework import test_util
 # pylint: enable=g-direct-tensorflow-import
 
+GPU_OPTIONS = tf.GPUOptions(allow_growth=True)
+CONFIG = tf.ConfigProto(gpu_options=GPU_OPTIONS)
+
+
 
 class _FakeSummary(Summary):
   """A fake adanet.Summary."""
@@ -580,7 +584,7 @@ class ComplexityRegularizedEnsemblerTest(parameterized.TestCase,
       train_op = ensembler.build_train_op(
           self._build_easy_ensemble([self._build_subnetwork()]), dummy_loss,
           [dummy_weight], *[None] * 4)
-      with tf_compat.v1.Session() as sess:
+      with tf_compat.v1.Session(config=CONFIG) as sess:
         sess.run(tf_compat.v1.global_variables_initializer())
         sess.run(train_op)
         self.assertAllClose(-.2, sess.run(dummy_weight))
@@ -595,7 +599,7 @@ class ComplexityRegularizedEnsemblerTest(parameterized.TestCase,
       train_op = ensembler.build_train_op(
           self._build_easy_ensemble([self._build_subnetwork()]), dummy_loss,
           [dummy_weight], *[None] * 4)
-      with tf_compat.v1.Session() as sess:
+      with tf_compat.v1.Session(config=CONFIG) as sess:
         sess.run(tf_compat.v1.global_variables_initializer())
         sess.run(train_op)
         self.assertAllClose(-.2, sess.run(dummy_weight))

--- a/adanet/ensemble/weighted_test.py
+++ b/adanet/ensemble/weighted_test.py
@@ -34,9 +34,6 @@ from tensorflow.python.eager import context
 from tensorflow.python.framework import test_util
 # pylint: enable=g-direct-tensorflow-import
 
-GPU_OPTIONS = tf.GPUOptions(allow_growth=True)
-CONFIG = tf.ConfigProto(gpu_options=GPU_OPTIONS)
-
 
 
 class _FakeSummary(Summary):
@@ -584,7 +581,8 @@ class ComplexityRegularizedEnsemblerTest(parameterized.TestCase,
       train_op = ensembler.build_train_op(
           self._build_easy_ensemble([self._build_subnetwork()]), dummy_loss,
           [dummy_weight], *[None] * 4)
-      with tf_compat.v1.Session(config=CONFIG) as sess:
+      config = tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))
+      with tf_compat.v1.Session(config=config) as sess:
         sess.run(tf_compat.v1.global_variables_initializer())
         sess.run(train_op)
         self.assertAllClose(-.2, sess.run(dummy_weight))
@@ -599,7 +597,8 @@ class ComplexityRegularizedEnsemblerTest(parameterized.TestCase,
       train_op = ensembler.build_train_op(
           self._build_easy_ensemble([self._build_subnetwork()]), dummy_loss,
           [dummy_weight], *[None] * 4)
-      with tf_compat.v1.Session(config=CONFIG) as sess:
+      config = tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))
+      with tf_compat.v1.Session(config=config) as sess:
         sess.run(tf_compat.v1.global_variables_initializer())
         sess.run(train_op)
         self.assertAllClose(-.2, sess.run(dummy_weight))


### PR DESCRIPTION
When I was using AdaNet, I found that the model always took the whole available memory on GPU. Therefore, I did these modifications, to make sure that it only takes the GPU memory it needs, so we could utilize AdaNet and GPU better. 